### PR TITLE
Add bhyve/set command to accept direct/raw command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,14 @@ bhyve/device/ABC12345/zone/2/set
 ```
 * **bhyve/device/refresh** - casues all devices to refresh details
 * **bhyve/device/{deviceID}/refresh** - casues individual device to refresh details (not yet implemented)
-
+* **bhyve/set** - _json_ - sends a raw JSON command. Examples:
+```
+// set a 24 hour rain delay
+bhyve/set
+{"event":"rain_delay","delay":24,"device_id":"XXXXXX","timestamp":"2020-02-05T14:00:00.000Z"}
+```
+```
+// clear/cancel rain delay
+bhyve/set
+{"event":"rain_delay","delay":0,"device_id":"XXXXXX","timestamp":"2020-02-05T14:00:00.000Z"}
+```

--- a/app/app.js
+++ b/app/app.js
@@ -90,6 +90,7 @@ let subscribeHandler = function (topic) {
 oClient.on('devices', (data) => {
   if (MCLIENT_ONLINE) {
     let devices = []
+    subscribeHandler(`bhyve/set`)
     subscribeHandler(`bhyve/device/refresh`)
     for (let prop in data) {
       if (data.hasOwnProperty(prop)) {
@@ -173,6 +174,10 @@ const parseMessage = (topic, message) => {
     case 'bhyve/device/refresh':
       console.log(`${ts()} - refresh`)
       oClient.devices()
+      break
+    case 'bhyve/set':
+      oClient.send(JSON.parse(message.toString()))
+      console.log(`${ts()} - set: ${message}`)
       break
     default:
       console.log(`${ts()} - default: ${topic}`)


### PR DESCRIPTION
Adds `bhyve/set` command. The content of the command gets passed directly to oClient.send(). This will open up the possibility to directly communicate with the orbit server