### PR TITLE
ci(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,24 +8,30 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for npm trusted publishing via OIDC (no token needed)
+  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           release-type: node
 
       # Only proceed with the following steps if a release was created
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: ${{ steps.release.outputs.release_created }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+
+      # Trusted publishing requires npm >= 11.5.1 (newer than what Node bundles)
+      - run: npm install -g npm@latest
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm ci
@@ -34,17 +40,17 @@ jobs:
       - run: npm test
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm run build # Optional if not covered by prepublishOnly
+      - run: npm run build
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      # Publishes via OIDC trusted publishing; provenance is generated automatically
+      - name: Publish to npm
         if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --access public
 
       - name: Trigger Docker workflow
         if: ${{ steps.release.outputs.release_created }}
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           event-type: release-published
           client-payload: '{"release": {"tag_name": "${{ steps.release.outputs.tag_name }}"}}'


### PR DESCRIPTION
## Summary

Switches the release workflow to npm **OIDC trusted publishing**, matching the workflow in [billchurch/bhyve-api](https://github.com/billchurch/bhyve-api/blob/main/.github/workflows/release-please.yaml):

- Add `id-token: write` permission and remove `NODE_AUTH_TOKEN` from `npm publish` — provenance is generated automatically.
- Install `npm@latest` before publishing, since trusted publishing requires npm ≥ 11.5.1 (newer than what Node bundles).
- Pin all actions to commit SHAs at the same versions bhyve-api uses: release-please v5.0.0, checkout v6.0.3, setup-node v6.4.0 (Node 22).
- Keep this repo's Docker-dispatch step (not present in bhyve-api), pinned by SHA and bumped from repository-dispatch v2 → v4.0.1.

## Before the next release

1. Configure the **trusted publisher** on npmjs.com for the `bhyve-mqtt` package (Settings → Trusted Publisher → GitHub Actions: repo `billchurch/bhyve-mqtt`, workflow `release-please.yaml`) — publishing will fail without it.
2. After the first successful OIDC publish, the `NODE_AUTH_TOKEN` repo secret can be deleted.

https://claude.ai/code/session_015PWfEXnAeAM6AewhoEoA2w

---
_Generated by [Claude Code](https://claude.ai/code/session_015PWfEXnAeAM6AewhoEoA2w)_