### PR TITLE
fix(docker): use node:22-alpine to restore 32-bit ARM builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-FROM node:24-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /build
 COPY package.json package-lock.json ./
 RUN npm ci
 
 # Production stage
-FROM node:24-alpine
+FROM node:22-alpine
 LABEL maintainer="Bill Church <github.com/billchurch>"
 LABEL description="Unofficial Orbit Bhyve API to MQTT gateway"
 LABEL version="1.0"


### PR DESCRIPTION
## Summary

The v0.3.2 release pipeline succeeded through the npm OIDC publish, but the dispatched **Docker Build and Publish** run [failed](https://github.com/billchurch/bhyve-mqtt/actions/runs/27236237132): `node:24-alpine` (introduced in #62) doesn't publish `linux/arm/v7` or `linux/arm/v6` images, and the workflow builds all four platforms:

```
ERROR: failed to solve: node:24-alpine: failed to resolve source metadata for
docker.io/library/node:24-alpine: no match for platform in manifest: not found
```

**Fix:** base image `node:24-alpine` → `node:22-alpine`. Verified against Docker Hub that `22-alpine` ships `linux/amd64`, `arm64/v8`, `arm/v7`, and `arm/v6`. Node 22 is in LTS maintenance until April 2027, so this keeps 32-bit Raspberry Pi support without an EOL runtime.

## After merge

Re-run the image publish for the release via `workflow_dispatch` of `docker-publish.yaml` with `tag_name: v0.3.2` (I can trigger this once merged).

https://claude.ai/code/session_015PWfEXnAeAM6AewhoEoA2w

---
_Generated by [Claude Code](https://claude.ai/code/session_015PWfEXnAeAM6AewhoEoA2w)_