### PR TITLE
docs: align README and engines with current Node/runtime versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This app is designed to subscribe to the Orbit B-Hyve API and broadcast the mess
 
 ## Requirements
 
-- Node.js v18 or higher
+- Node.js v22 or higher (the Docker image and CI run Node 22 LTS)
 - MQTT broker (like Mosquitto, HiveMQ, etc.)
 - Orbit B-Hyve account and devices
 
@@ -28,8 +28,6 @@ cp .env-sample .env
 npm install
 npm start
 ```
-
-> **Note:** The project structure has been updated. The application code is now in the `/src` directory instead of `/app` directory, following standard Node.js project layout.
 
 ## Docker Usage
 
@@ -170,22 +168,17 @@ docker run -d --name bhyve-mqtt --env-file .env billchurch/bhyve-mqtt:latest
 For Docker Compose:
 
 ```bash
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
-## Testing
+## Code Quality
 
-The project includes several test scripts to verify functionality:
-
-- **test-api.js** - Tests the bhyve-api connection only
-- **test-mqtt.js** - Tests MQTT connectivity only
-- **test-integration.js** - Full end-to-end integration test
-
-To run tests:
+`npm test` runs ESLint over the project (no runtime test suite at the moment):
 
 ```bash
-npm run test
+npm run test   # eslint . --max-warnings 0
+npm run lint:fix
 ```
 
 ## Uses bhyve-api
@@ -273,8 +266,6 @@ docker rm -f bhyve-mqtt
 For easier management, you can use Docker Compose. Create a `docker-compose.yml` file:
 
 ```yaml
-version: '3'
-
 services:
   bhyve-mqtt:
     image: bhyve-mqtt:latest
@@ -287,5 +278,5 @@ services:
 Then run:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "mqtt"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "start": "node src/app.js",


### PR DESCRIPTION
## Summary

Aligns the README (and `package.json` engines) with where the project actually is after this week's updates:

- **Node requirement: v18 → v22.** Node 18 and 20 are both EOL; the Docker image and the release CI now run Node 22 LTS. `engines.node` bumped to `>=22.0.0` to match (npm only warns on mismatch, it doesn't block installs).
- **Testing section rewritten** — it referenced `test-api.js`, `test-mqtt.js`, and `test-integration.js`, which no longer exist in the repo. `npm test` runs ESLint; the section now says so.
- **Docker Compose snippets modernized** — dropped the obsolete `version: '3'` key and switched `docker-compose` → `docker compose`.
- **Removed the stale `/app` → `/src` migration note** from the install section.

Lint passes (`npm test`).

https://claude.ai/code/session_015PWfEXnAeAM6AewhoEoA2w

---
_Generated by [Claude Code](https://claude.ai/code/session_015PWfEXnAeAM6AewhoEoA2w)_